### PR TITLE
terraform: update default version

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -32,8 +32,9 @@
   name: cycloid.telegraf
   scm: git
 
+# keep compatible with ansible 2.9
 - src: https://github.com/dj-wasabi/ansible-telegraf
-  version: master
+  version: 0.14.0
   name: dj-wasabi.telegraf
   scm: git
 

--- a/pipeline/variables.sample.yml
+++ b/pipeline/variables.sample.yml
@@ -127,4 +127,4 @@ debug_public_key: ""
 
 #. terraform_version (required): '1.0.1'
 #+ terraform version used to execute your code.
-terraform_version: '1.0.1'
+terraform_version: '1.6.3'


### PR DESCRIPTION
Fix telegraf verstion to be compatible with ansible 2.9